### PR TITLE
fix missing initial_layout

### DIFF
--- a/measurement_mitigation/measurement_mitigation.ipynb
+++ b/measurement_mitigation/measurement_mitigation.ipynb
@@ -90,7 +90,12 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "e9687305",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:22:58.253261Z",
+     "start_time": "2021-12-14T16:22:55.423008Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -106,7 +111,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "4eb75f56",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:11.170138Z",
+     "start_time": "2021-12-14T16:22:58.255099Z"
+    }
+   },
    "outputs": [],
    "source": [
     "IBMQ.load_account();"
@@ -274,7 +284,12 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "1fbe200d",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:12.165442Z",
+     "start_time": "2021-12-14T16:23:11.173340Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -309,7 +324,12 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "39506756",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:12.176844Z",
+     "start_time": "2021-12-14T16:23:12.168729Z"
+    }
+   },
    "outputs": [],
    "source": [
     "backend = FakeMumbai()"
@@ -319,7 +339,12 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "7eb32431",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:14.154026Z",
+     "start_time": "2021-12-14T16:23:12.179467Z"
+    }
+   },
    "outputs": [],
    "source": [
     "trans_qc = transpile([qc_bv]*10, backend, optimization_level=3, initial_layout=[3, 0, 4, 2, 7, 1])\n",
@@ -332,7 +357,12 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "41f36557",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.709646Z",
+     "start_time": "2021-12-14T16:23:14.156068Z"
+    }
+   },
    "outputs": [],
    "source": [
     "shots = 4000\n",
@@ -343,13 +373,18 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "bc393783",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.715365Z",
+     "start_time": "2021-12-14T16:23:15.711537Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'01000': 1, '11000': 1, '11100': 5, '10010': 1, '00010': 2, '00111': 55, '10100': 3, '10001': 3, '10011': 6, '01110': 12, '00101': 4, '10101': 2, '01101': 3, '10111': 134, '00001': 87, '11010': 7, '01011': 14, '00000': 22, '11001': 7, '00110': 4, '11101': 94, '00011': 56, '11110': 205, '11111': 2964, '10110': 29, '01001': 3, '11011': 105, '01111': 171}\n"
+      "{'00100': 1, '11100': 4, '01001': 1, '10000': 1, '11001': 5, '10001': 4, '10010': 1, '00010': 4, '11000': 1, '00101': 3, '10101': 6, '10011': 8, '01110': 10, '01011': 22, '00001': 92, '11010': 12, '00000': 34, '00111': 61, '10100': 2, '01101': 7, '10111': 126, '01010': 1, '11110': 181, '01111': 181, '11011': 110, '00011': 49, '11111': 2931, '10110': 37, '00110': 2, '11101': 103}\n"
      ]
     }
    ],
@@ -369,12 +404,17 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "5888d71d",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.725119Z",
+     "start_time": "2021-12-14T16:23:15.720746Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.00725"
+       "0.00925"
       ]
      },
      "execution_count": 8,
@@ -401,7 +441,12 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "3077a25a",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.733761Z",
+     "start_time": "2021-12-14T16:23:15.728955Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -434,12 +479,17 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "cbf92f2e",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.740269Z",
+     "start_time": "2021-12-14T16:23:15.736031Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-0.00725"
+       "-0.00925"
       ]
      },
      "execution_count": 10,
@@ -463,13 +513,18 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "bdc5f67a",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.747896Z",
+     "start_time": "2021-12-14T16:23:15.742576Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Expectation value: -0.597\n"
+      "Expectation value: -0.6005\n"
      ]
     }
    ],
@@ -498,7 +553,12 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "79680c9c",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.755542Z",
+     "start_time": "2021-12-14T16:23:15.750313Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def expectation_value(counts, operator):\n",
@@ -528,7 +588,12 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "ec1a835c",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:15.763997Z",
+     "start_time": "2021-12-14T16:23:15.758268Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -599,7 +664,12 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "aebe3e52",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:16.170112Z",
+     "start_time": "2021-12-14T16:23:15.766597Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -644,7 +714,12 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "e1f411c5",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:16.257228Z",
+     "start_time": "2021-12-14T16:23:16.172047Z"
+    }
+   },
    "outputs": [],
    "source": [
     "state_vec = Statevector.from_instruction(qc)\n",
@@ -663,7 +738,12 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "48448131",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:16.277105Z",
+     "start_time": "2021-12-14T16:23:16.258837Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -703,7 +783,12 @@
    "cell_type": "code",
    "execution_count": 17,
    "id": "151cc69b",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:16.281769Z",
+     "start_time": "2021-12-14T16:23:16.279277Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mit = mthree.M3Mitigation(backend)"
@@ -721,7 +806,12 @@
    "cell_type": "code",
    "execution_count": 18,
    "id": "c19b3075",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:19.291548Z",
+     "start_time": "2021-12-14T16:23:16.283587Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mit.cals_from_system(qubits, method='independent')"
@@ -739,7 +829,12 @@
    "cell_type": "code",
    "execution_count": 19,
    "id": "3b07dcda",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:19.296406Z",
+     "start_time": "2021-12-14T16:23:19.293500Z"
+    }
+   },
    "outputs": [],
    "source": [
     "qc_plus_meas = qc.measure_all(inplace=False)"
@@ -749,10 +844,15 @@
    "cell_type": "code",
    "execution_count": 20,
    "id": "3ced01a4",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:22.705580Z",
+     "start_time": "2021-12-14T16:23:19.298344Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "trans_qc = transpile(qc_plus_meas, backend)\n",
+    "trans_qc = transpile(qc_plus_meas, backend, initial_layout=qubits)\n",
     "raw_counts = backend.run(trans_qc, shots=10000).result().get_counts()"
    ]
   },
@@ -768,12 +868,17 @@
    "cell_type": "code",
    "execution_count": 21,
    "id": "f5ae337f",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:22.714732Z",
+     "start_time": "2021-12-14T16:23:22.707437Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.05459999999999994"
+       "0.1327999999999998"
       ]
      },
      "execution_count": 21,
@@ -797,7 +902,12 @@
    "cell_type": "code",
    "execution_count": 22,
    "id": "f3934cb3",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:22.734455Z",
+     "start_time": "2021-12-14T16:23:22.717160Z"
+    }
+   },
    "outputs": [],
    "source": [
     "quasi_probs = mit.apply_correction(raw_counts, qubits)"
@@ -815,12 +925,17 @@
    "cell_type": "code",
    "execution_count": 23,
    "id": "999c1987",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:22.749740Z",
+     "start_time": "2021-12-14T16:23:22.742075Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.14592727116993148"
+       "0.34637046078415523"
       ]
      },
      "execution_count": 23,
@@ -846,7 +961,12 @@
    "cell_type": "code",
    "execution_count": 24,
    "id": "e5daffec",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:22.757223Z",
+     "start_time": "2021-12-14T16:23:22.752900Z"
+    }
+   },
    "outputs": [],
    "source": [
     "N = 6\n",
@@ -860,7 +980,12 @@
    "cell_type": "code",
    "execution_count": 25,
    "id": "ba3bf118",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:24.146758Z",
+     "start_time": "2021-12-14T16:23:22.760413Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -896,7 +1021,12 @@
    "cell_type": "code",
    "execution_count": 26,
    "id": "9ecb59ba",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:24.153869Z",
+     "start_time": "2021-12-14T16:23:24.149205Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -926,7 +1056,12 @@
    "cell_type": "code",
    "execution_count": 27,
    "id": "04dcc440",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:25.749458Z",
+     "start_time": "2021-12-14T16:23:24.155653Z"
+    }
+   },
    "outputs": [],
    "source": [
     "raw_counts2 = backend.run(trans_qc2, shots=10000).result().get_counts()"
@@ -936,12 +1071,17 @@
    "cell_type": "code",
    "execution_count": 28,
    "id": "72db7406",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:25.755889Z",
+     "start_time": "2021-12-14T16:23:25.751283Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.6396"
+       "0.6464"
       ]
      },
      "execution_count": 28,
@@ -965,7 +1105,12 @@
    "cell_type": "code",
    "execution_count": 29,
    "id": "a240278c",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:27.923970Z",
+     "start_time": "2021-12-14T16:23:25.758209Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mit = mthree.M3Mitigation(backend)\n",
@@ -984,7 +1129,12 @@
    "cell_type": "code",
    "execution_count": 30,
    "id": "75fab927",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:27.929011Z",
+     "start_time": "2021-12-14T16:23:27.925748Z"
+    }
+   },
    "outputs": [],
    "source": [
     "quasi_prob2 = mit.apply_correction(raw_counts2, final_map)"
@@ -994,12 +1144,17 @@
    "cell_type": "code",
    "execution_count": 31,
    "id": "f20fa782",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:27.938526Z",
+     "start_time": "2021-12-14T16:23:27.931437Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.8257996459173018"
+       "0.8357904553634354"
       ]
      },
      "execution_count": 31,
@@ -1025,57 +1180,62 @@
    "cell_type": "code",
    "execution_count": 32,
    "id": "efb671aa",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:27.947266Z",
+     "start_time": "2021-12-14T16:23:27.941096Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'110110': 5.009010576411074e-06,\n",
-       " '011000': 1.8843186291265155e-05,\n",
-       " '101110': 2.0627379961496512e-05,\n",
-       " '011101': 3.437488208836698e-05,\n",
-       " '010010': 4.683476333171993e-05,\n",
-       " '011100': 5.177510947031782e-05,\n",
-       " '011011': 5.718764160381869e-05,\n",
-       " '001111': 5.800433516431424e-05,\n",
-       " '010101': 6.157109319418431e-05,\n",
-       " '001100': 7.983259391098423e-05,\n",
-       " '001010': 0.0001051145842422604,\n",
-       " '010100': 0.0001076663409349449,\n",
-       " '011010': 0.00011312010905190054,\n",
-       " '100110': 0.00012893851975533167,\n",
-       " '010001': 0.00014018582043785142,\n",
-       " '010110': 0.00014162590979997596,\n",
-       " '010011': 0.0001512163970507106,\n",
-       " '111000': 0.0001672832442739644,\n",
-       " '101100': 0.00016961028460834711,\n",
-       " '000011': 0.00020362383063453273,\n",
-       " '001001': 0.00025116135809855614,\n",
-       " '110101': 0.00027553532855203956,\n",
-       " '111010': 0.0005461482842454649,\n",
-       " '101000': 0.0006559823776728074,\n",
-       " '000100': 0.0008078511257783652,\n",
-       " '101011': 0.001844792545360524,\n",
-       " '010000': 0.0021633182524277337,\n",
-       " '001000': 0.002315084088984433,\n",
-       " '000001': 0.0029400327803077607,\n",
-       " '110001': 0.0036034522504666392,\n",
-       " '010111': 0.0038125153923606937,\n",
-       " '111001': 0.004073982638744152,\n",
-       " '111110': 0.004348455001654956,\n",
-       " '100001': 0.004482681649822564,\n",
-       " '000110': 0.004629896889840184,\n",
-       " '100000': 0.004716915962595959,\n",
-       " '011110': 0.005246125659296248,\n",
-       " '001110': 0.006471398971069935,\n",
-       " '000010': 0.006542736137886833,\n",
-       " '111011': 0.006820144450267192,\n",
-       " '101111': 0.007898931666502587,\n",
-       " '111101': 0.009356411110009646,\n",
-       " '011111': 0.011453617465903532,\n",
-       " '110111': 0.016197967394793785,\n",
-       " '111111': 0.42148149566771753,\n",
-       " '000000': 0.46520092051325723}"
+       "{'001100': 3.5106822519470054e-05,\n",
+       " '001101': 4.4218597581817217e-05,\n",
+       " '110100': 5.315019653917632e-05,\n",
+       " '000101': 5.6728149991546286e-05,\n",
+       " '101100': 6.410651788398967e-05,\n",
+       " '010101': 7.277321308925916e-05,\n",
+       " '011011': 7.49095695014049e-05,\n",
+       " '101010': 8.913203829514313e-05,\n",
+       " '110011': 0.00010551346340029729,\n",
+       " '110110': 0.00013398624727717812,\n",
+       " '011010': 0.00013475502327524964,\n",
+       " '100110': 0.00018491175635013384,\n",
+       " '101000': 0.0002337509212020715,\n",
+       " '001001': 0.00025106526009134497,\n",
+       " '100011': 0.00028372935425722754,\n",
+       " '011001': 0.00028701927561988175,\n",
+       " '111000': 0.0002946179377132366,\n",
+       " '010100': 0.0003205957316457862,\n",
+       " '010010': 0.00038295926574622097,\n",
+       " '010000': 0.00039264985654623445,\n",
+       " '101001': 0.0004650496452516489,\n",
+       " '100010': 0.0004752290698262097,\n",
+       " '001010': 0.0005378481570241633,\n",
+       " '010001': 0.0005505835971306296,\n",
+       " '100111': 0.0007400380950276359,\n",
+       " '001000': 0.0015524144332572124,\n",
+       " '101011': 0.002105101936189599,\n",
+       " '000001': 0.0028290026420137917,\n",
+       " '100001': 0.0030851703078094844,\n",
+       " '000100': 0.003179513178190884,\n",
+       " '010111': 0.0037685256582475203,\n",
+       " '100000': 0.004017275251719297,\n",
+       " '111011': 0.004104112930529622,\n",
+       " '011110': 0.004467402048602917,\n",
+       " '111001': 0.0044858588067056785,\n",
+       " '110001': 0.004705501949731115,\n",
+       " '101111': 0.004978490292045306,\n",
+       " '000110': 0.0058565300341135405,\n",
+       " '001110': 0.007349842608795792,\n",
+       " '111110': 0.00752733897996426,\n",
+       " '011111': 0.008472973792607053,\n",
+       " '000010': 0.00913309932184419,\n",
+       " '110111': 0.009181794003728662,\n",
+       " '111101': 0.011824651327601401,\n",
+       " '111111': 0.43944574445904355,\n",
+       " '000000': 0.451665228274472}"
       ]
      },
      "execution_count": 32,
@@ -1110,12 +1270,17 @@
    "cell_type": "code",
    "execution_count": 33,
    "id": "91c34b15",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-14T16:23:28.607744Z",
+     "start_time": "2021-12-14T16:23:27.949513Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.19.0</td></tr><tr><td><code>qiskit-aer</code></td><td>0.9.1</td></tr><tr><td><code>qiskit-ignis</code></td><td>0.7.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.18.1</td></tr><tr><td><code>qiskit-aqua</code></td><td>0.9.5</td></tr><tr><td><code>qiskit</code></td><td>0.33.0</td></tr><tr><td><code>qiskit-nature</code></td><td>0.2.2</td></tr><tr><td><code>qiskit-machine-learning</code></td><td>0.2.1</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.6</td></tr><tr><td>Python compiler</td><td>Clang 10.0.0 </td></tr><tr><td>Python build</td><td>default, Aug 18 2021 12:38:10</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>4</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Dec 10 10:44:42 2021 EST</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.19.0</td></tr><tr><td><code>qiskit-aer</code></td><td>0.9.1</td></tr><tr><td><code>qiskit-ignis</code></td><td>0.7.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.18.1</td></tr><tr><td><code>qiskit-aqua</code></td><td>0.9.5</td></tr><tr><td><code>qiskit</code></td><td>0.33.0</td></tr><tr><td><code>qiskit-nature</code></td><td>0.2.2</td></tr><tr><td><code>qiskit-machine-learning</code></td><td>0.2.1</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.6</td></tr><tr><td>Python compiler</td><td>Clang 10.0.0 </td></tr><tr><td>Python build</td><td>default, Aug 18 2021 12:38:10</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>4</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Tue Dec 14 11:23:28 2021 EST</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"


### PR DESCRIPTION
Fix a missing `initial_layout` call in the measurement mitigation notebook.